### PR TITLE
getWindow not returning a DOM window

### DIFF
--- a/vs.d.ts
+++ b/vs.d.ts
@@ -543,7 +543,7 @@ declare namespace __vis {
     getItemRange(): any; // TODO
     getSelection(): Array<IdType>;
     getVisibleItems(): Array<IdType>;
-    getWindow(): Window;
+    getWindow(): {start: Date, end: Date};
     moveTo(time: DateType, options?: TimelineFitOptions): void;
     on(event: TimelineEvents, callback: Function): void;
     off(event: TimelineEvents, callback: Function): void;


### PR DESCRIPTION
getWindow is not returning a DOM window but an object with start and end dates as you can see here:
http://visjs.org/docs/timeline/#Methods